### PR TITLE
Update conway-genesis-file with correct values 

### DIFF
--- a/conway-genesis.json
+++ b/conway-genesis.json
@@ -4,19 +4,19 @@
     "committeeNoConfidence": 0.51,
     "hardForkInitiation": 0.51,
     "motionNoConfidence": 0.60,
-    "ppSecurityGroup": 0.51
+    "ppSecurityGroup": 0.60
   },
   "dRepVotingThresholds": {
     "motionNoConfidence": 0.67,
     "committeeNormal": 0.67,
     "committeeNoConfidence": 0.60,
-    "updateToConstitution": 0.85,
+    "updateToConstitution": 0.75,
     "hardForkInitiation": 0.60,
     "ppNetworkGroup": 0.67,
     "ppEconomicGroup": 0.67,
     "ppTechnicalGroup": 0.67,
-    "ppGovGroup": 0.85,
-    "treasuryWithdrawal": 0.75
+    "ppGovGroup": 0.75,
+    "treasuryWithdrawal": 0.67
   },
   "committeeMinSize": 7,
   "committeeMaxTermLength": 73,


### PR DESCRIPTION
for the following parameters:
- `ppSecurityGroup` -> should be 60% to mirror the currently highest threshold % for pools
- `updateToConstittution` according to our recommendations value should be 75%
- `ppGovGroup` according to our recommendations value should be 75%
- `treasuryWithdrawal` according to our recommendations value should be 67%